### PR TITLE
Fixing non same-site cookies

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.h2.console.enabled=true
 spring.h2.console.settings.web-allow-others=true
 spring.jackson.mapper.default-view-inclusion=true
+server.servlet.session.cookie.same-site=none


### PR DESCRIPTION
To fix `This Set-Cookie didn't specify a "SameSite" attribute and was default to "SameSite=Lax"` error on production